### PR TITLE
Fix to let Doctrine choose the generated value strategy

### DIFF
--- a/src/Entity/SlackLink.php
+++ b/src/Entity/SlackLink.php
@@ -12,7 +12,7 @@ class SlackLink
     /**
      * @ORM\Id
      * @ORM\Column(type="integer")
-     * @ORM\GeneratedValue(strategy="SEQUENCE")
+     * @ORM\GeneratedValue(strategy="AUTO")
      */
     private $id;
 


### PR DESCRIPTION
The `SEQUENCE` strategy is not available in MySQL/MsSQL/SQLite, so i've changed to `AUTO` to let Doctrine choose the good strategy to use following the configured engine.

See [http://docs.doctrine-project.org/en/latest/reference/basic-mapping.html#identifier-generation-strategies](http://docs.doctrine-project.org/en/latest/reference/basic-mapping.html#identifier-generation-strategies)